### PR TITLE
Add translation fallback to English

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,7 @@ gulp.task('i18n', function(){
       langDir: 'lang', // takes translations from /lang/
       createLangDirs: true,
       defaultLang: 'en',
+      fallback: 'en',
       delimiters: ['$(',')$']
     }))
     .pipe(gulp.dest('dist'));


### PR DESCRIPTION
In case a string isn't translated into a language, it will be displayed in
English by default.